### PR TITLE
Fixup more harmless C++ warnings

### DIFF
--- a/include/sympack/SuperNode.hpp
+++ b/include/sympack/SuperNode.hpp
@@ -29,7 +29,7 @@ namespace symPACK{
     bool Last;
     Int GIndex;
     size_t Offset;
-    NZBlockDesc():GIndex(-1),Offset(-1),Last(false){};
+    NZBlockDesc():GIndex(-1),Offset((size_t)-1),Last(false){};
     NZBlockDesc(Int aGIndex, size_t aOffset):GIndex(aGIndex),Offset(aOffset),Last(false){};
   };
 

--- a/include/sympack/impl/DistSparseMatrix_impl.hpp
+++ b/include/sympack/impl/DistSparseMatrix_impl.hpp
@@ -551,7 +551,7 @@ namespace symPACK{
     HMat.size = *n;
     graph.size = HMat.size;
 
-    assert(n>0);
+    assert(n);
     //find baseval in first column
     int baseval = 0;
     int keepdiag = 1;

--- a/include/sympack/impl/symPACKMatrix_impl.hpp
+++ b/include/sympack/impl/symPACKMatrix_impl.hpp
@@ -51,9 +51,9 @@ namespace symPACK{
           Ptr lfi = this->locXlindx_[locsupno-1];
           Ptr lli = this->locXlindx_[locsupno]-1;
 
-          Idx blockIdx = -1;
-          Idx prevRow = -1;
-          Idx prevSnode = -1;
+          Idx blockIdx  = (Idx)-1;
+          Idx prevRow   = (Idx)-1;
+          Idx prevSnode = (Idx)-1;
 
           for(Ptr sidx = lfi; sidx<=lli;sidx++){
             Idx row = this->locLindx_[sidx-1];
@@ -548,7 +548,7 @@ namespace symPACK{
 #endif
 
       Idx nzBlockCnt = 1;
-      Idx prevSnode = -1;
+      Idx prevSnode = (Idx)-1;
       for(Ptr sidx = lfi; sidx<=lli;sidx++){
 
         Idx row = this->locLindx_[sidx-1];

--- a/include/sympack/impl/symPACKMatrix_impl_FB_pull.hpp
+++ b/include/sympack/impl/symPACKMatrix_impl_FB_pull.hpp
@@ -1029,7 +1029,7 @@ template <typename T> inline void symPACKMatrix<T>::FBGetUpdateCount(std::vector
 
     Ptr lfi = this->locXlindx_[locsupno-1];
     Ptr lli = this->locXlindx_[locsupno]-1;
-    Idx prevSnode = -1;
+    Idx prevSnode = (Idx)-1;
     for (Ptr sidx = lfi; sidx<=lli;sidx++) {
       Idx row = this->locLindx_[sidx-1];
       Int supno = this->SupMembership_[row-1];
@@ -1209,7 +1209,7 @@ template <typename T> inline void symPACKMatrix<T>::FBGetUpdateCount(std::vector
 
       Ptr lfi = this->locXlindx_[locsupno-1];
       Ptr lli = this->locXlindx_[locsupno]-1;
-      Idx prevSnode  =-1;
+      Idx prevSnode = (Idx)-1;
       for (Ptr sidx = lfi; sidx<=lli;sidx++) {
         Idx row = this->locLindx_[sidx-1];
         Int supno = this->SupMembership_[row-1];

--- a/include/sympack/lapack.hpp
+++ b/include/sympack/lapack.hpp
@@ -311,7 +311,7 @@ namespace symPACK {
         if ( !UPPER  && *UPLO!= 'L' ) {
           INFO = -1;
         }
-        else if ( N < 0 ) {
+        else if ( N > 0x7FFFFFFF ) { // means N would be overflow a signed 32-bit int
           INFO = -2;
         }
         else if ( LDA < std::max(Idx(1),N) ) {
@@ -505,7 +505,7 @@ namespace symPACK {
         if ( !UPPER  && *UPLO!= 'L' ) {
           INFO = -1;
         }
-        else if ( N < 0 ) {
+        else if ( N > 0x7FFFFFFF ) { // means N would be overflow a signed 32-bit int
           INFO = -2;
         }
         else if ( LDA < std::max(Idx(1),N) ) {

--- a/include/sympack/mpi_interf.hpp
+++ b/include/sympack/mpi_interf.hpp
@@ -73,9 +73,9 @@ inline int Alltoallv(_Container & sendbuf, const _Size *stotcounts, const _Size 
   bool is_signed = std::numeric_limits<_Size>::is_signed;
   
   //first check that everything is positive
-  if ( is_signed && 
-      (std::any_of(stotcounts,stotcounts+mpisize,[](const _Size & a){ return a < 0;}) || 
-                std::any_of(stotdispls,stotdispls+mpisize,[](const _Size & a){ return a < 0;}) ) ) {
+  if ( is_signed &&  // cast to intmax avoids compile warnings when _Size is unsigned
+      (std::any_of(stotcounts,stotcounts+mpisize,[](const _Size & a){ return std::intmax_t(a) < 0;}) || 
+                std::any_of(stotdispls,stotdispls+mpisize,[](const _Size & a){ return std::intmax_t(a) < 0;}) ) ) {
     return -1;
   }
 

--- a/include/sympack/symPACKMatrix2D.hpp
+++ b/include/sympack/symPACKMatrix2D.hpp
@@ -3360,7 +3360,7 @@ namespace symPACK{
             std::list<Int> ancestor_rows;
 
             Int K = -1; 
-            Idx K_prevSnode = -1;
+            Idx K_prevSnode = (Idx)-1;
             for (Ptr K_sidx = lfi; K_sidx<=lli;K_sidx++) {
               Idx K_row = this->locLindx_[K_sidx-1];
               K = this->SupMembership_[K_row-1];
@@ -4617,7 +4617,7 @@ namespace symPACK{
             std::list<Int> ancestor_rows;
 
             Int K = -1; 
-            Idx K_prevSnode = -1;
+            Idx K_prevSnode = (Idx)-1;
             for (Ptr K_sidx = lfi; K_sidx<=lli;K_sidx++) {
               Idx K_row = this->locLindx_[K_sidx-1];
               K = this->SupMembership_[K_row-1];


### PR DESCRIPTION
In particular, this addresses the following messages:

from `icc -Wextra`:
* warning #68: integer conversion resulted in a change of sign (many instances)
* include/sympack/lapack.hpp: warning #186: pointless comparison of unsigned integer with zero (two instances)
* mpi_interf.hpp: warning #186: pointless comparison of unsigned integer with zero (two instances)

from cce/9.0.1: (which subsequently fails to build for other, more fundamental reasons)
* include/sympack/impl/DistSparseMatrix_impl.hpp:554:13: error: ordered comparison between pointer and zero ('int *' and 'int')

These changes are sufficient to cleanly pass Intel C++ 19.0 -Wall -Wextra.

Note this is still NOT sufficient to cleanly pass Gnu g++'s stronger -Wall
which still generates nearly a thousand warnings (all of which are
-Wsign-compare, -Wunknown-pragma, -Wreorder, -Wswitch or
-Wdelete-non-virtual-dtor)