### PR TITLE
Remove extraneous trailing semicolons

### DIFF
--- a/driver/utils.hpp
+++ b/driver/utils.hpp
@@ -141,7 +141,7 @@ void check_solution( symPACK::DistSparseMatrix<SCALAR> & HMat, std::vector<SCALA
       std::cout<<"Norm of residual after factorization/solve is "<<normAX/normRHS<<std::endl;
     }
   }
-};
+}
 
 template<typename vdist_int, typename ptr_t, typename ind_t, typename SCALAR>
 void check_solution( int n, vdist_int * vertexDist, ptr_t * colptr, ind_t * rowind, SCALAR * nzvalLocal, std::vector<SCALAR> & RHS, std::vector<SCALAR> & XFinal, MPI_Comm & worldcomm ) {
@@ -194,7 +194,7 @@ void check_solution( int n, vdist_int * vertexDist, ptr_t * colptr, ind_t * rowi
       std::cout<<"Norm of residual after facotrization/solve is "<<normAX/normRHS<<std::endl;
     }
   }
-};
+}
 
 
 

--- a/include/sympack/datatypes.hpp
+++ b/include/sympack/datatypes.hpp
@@ -41,11 +41,11 @@ namespace symPACK {
   const Scalar SCALAR_MINUS_ONE = static_cast<Scalar>(-1.0);
 
   template<typename T>
-    const T ZERO(){ return static_cast<T>(0.0);};
+    const T ZERO(){ return static_cast<T>(0.0);}
   template<typename T>
-    const T ONE(){ return static_cast<T>(1.0);};
+    const T ONE(){ return static_cast<T>(1.0);}
   template<typename T>
-    const T MINUS_ONE(){ return static_cast<T>(-1.0);};
+    const T MINUS_ONE(){ return static_cast<T>(-1.0);}
 
 
 

--- a/include/sympack/impl/IntervalTree_impl.hpp
+++ b/include/sympack/impl/IntervalTree_impl.hpp
@@ -17,7 +17,7 @@ inline ITree<F>::ITNode<F> * ITree<F>::newNode_(ITree<F>::Interval<F> & i)
   temp->min = i.low;
 
   return temp;
-};
+}
 
 
   template<typename F>

--- a/include/sympack/impl/SuperNodeInd_impl.hpp
+++ b/include/sympack/impl/SuperNodeInd_impl.hpp
@@ -98,12 +98,12 @@ namespace symPACK{
 #else
       this->idxToBlk_ = this->CreateITree();
 #endif
-    }; 
+    } 
 
   template<typename T, class Allocator>
     SuperNodeInd<T,Allocator>::SuperNodeInd(Int aiId, Int aiFr, Int aiFc, Int aiLc, Int aiN, std::set<Idx> & rowIndices, Int panel):SuperNodeInd<T,Allocator>() {
       Init(aiId,aiFr,aiFc,aiLc,aiN,rowIndices,panel);
-    }; 
+    } 
 
   template<typename T, class Allocator>
     SuperNodeInd<T,Allocator>::SuperNodeInd(char * storage_ptr,size_t storage_size, Int GIndex ):SuperNodeInd<T,Allocator>() {
@@ -258,7 +258,7 @@ namespace symPACK{
         }
         this->AddNZBlock( prevRow - firstRow + 1, firstRow);
       }
-    }; 
+    } 
 
   template<typename T, class Allocator>
     inline void SuperNodeInd<T,Allocator>::AddNZBlock(Int aiNRows, Int aiGIndex){

--- a/include/sympack/impl/SuperNode_impl.hpp
+++ b/include/sympack/impl/SuperNode_impl.hpp
@@ -99,12 +99,12 @@ namespace symPACK{
 #else
       idxToBlk_ = CreateITree();
 #endif
-    }; 
+    } 
 
   template<typename T, class Allocator>
     SuperNode<T,Allocator>::SuperNode(Int aiId, Int aiFr, Int aiFc, Int aiLc, Int aiN, std::set<Idx> & rowIndices, Int panel):SuperNode<T,Allocator>() {
       Init(aiId,aiFr,aiFc,aiLc,aiN,rowIndices,panel);
-    }; 
+    } 
 
   template<typename T, class Allocator>
     SuperNode<T,Allocator>::SuperNode(char * storage_ptr,size_t storage_size, Int GIndex ):SuperNode<T,Allocator>() {
@@ -223,7 +223,7 @@ namespace symPACK{
         }
         this->AddNZBlock( prevRow - firstRow + 1, firstRow);
       }
-    }; 
+    } 
 
 
 

--- a/include/sympack/impl/symPACKMatrix_impl_FB_pull.hpp
+++ b/include/sympack/impl/symPACKMatrix_impl_FB_pull.hpp
@@ -23,7 +23,7 @@ template <typename T> inline void symPACKMatrix<T>::dfs_traversal(std::vector<st
       }
     }
   }
-};
+}
 
 template <typename T> inline void symPACKMatrix<T>::FanBoth() 
 {

--- a/include/sympack/mpi_interf.hpp
+++ b/include/sympack/mpi_interf.hpp
@@ -51,7 +51,7 @@ namespace symPACK{
         //Mark the Icomm as "full"
         allIcomm.setHead(totalSize);
         return ;
-      };		// -----  end of function Gatherv  ----- 
+      }		// -----  end of function Gatherv  ----- 
 
 
 
@@ -517,7 +517,7 @@ inline int Alltoallv(_Container & sendbuf, const _Size *stotcounts, const _Size 
 
 
 template<typename T>
-inline void Allreduce( T* sendbuf, T* recvbuf, Int count, MPI_Op op, MPI_Comm comm){};
+inline void Allreduce( T* sendbuf, T* recvbuf, Int count, MPI_Op op, MPI_Comm comm){}
 
 template<>
 inline void Allreduce<double>( double* sendbuf, double* recvbuf, Int count, MPI_Op op, MPI_Comm comm){

--- a/include/sympack/symPACKMatrix2D.hpp
+++ b/include/sympack/symPACKMatrix2D.hpp
@@ -430,7 +430,7 @@ namespace symPACK{
                 return std::get<2>(a->_meta) < std::get<2>(b->_meta);
               else
                 return std::get<4>(a->_meta)<std::get<4>(b->_meta); 
-            };
+            }
           };
           std::priority_queue<ttask_t*,std::vector<ttask_t*>,avail_comp> avail_tasks;
 #else
@@ -448,7 +448,7 @@ namespace symPACK{
                 return std::get<2>(a->_meta) < std::get<2>(b->_meta);
               else
                 return std::get<4>(a->_meta)<std::get<4>(b->_meta); 
-            };
+            }
           };
           std::priority_queue<ttask_t*,std::vector<ttask_t*>,rdy_comp> ready_tasks;
 #else
@@ -498,7 +498,7 @@ namespace symPACK{
             block_t * _blocks;
             size_t _nblocks;
 
-            block_container_t():_blocks(nullptr),_nblocks(0) {};
+            block_container_t():_blocks(nullptr),_nblocks(0) {}
 
             size_t size() const{
               return _nblocks;
@@ -1977,11 +1977,11 @@ namespace symPACK{
       std::vector< snodeBlock_sptr_t > localBlocks_;
       int nsuper;
       double mem_budget;
-      using cell_key_t = std::pair<uint64_t,uint64_t>;;
+      using cell_key_t = std::pair<uint64_t,uint64_t>;
       cell_key_t coord2supidx(uint64_t i, uint64_t j) { 
         cell_key_t val = std::make_pair(i,j);
         return val;
-      };
+      }
       std::map<cell_key_t, snodeBlockBase_sptr_t > cells_;
 
       inline snodeBlockBase_sptr_t pQueryCELL (int a, int b)  { 

--- a/include/sympack/utility.hpp
+++ b/include/sympack/utility.hpp
@@ -183,12 +183,12 @@ namespace symPACK{
   inline Int Print(std::ostream &os, const std::string name) {
     os << std::setiosflags(std::ios::left) << name << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const char* name) {
     os << std::setiosflags(std::ios::left) << std::string(name) << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const std::string name, std::string val) {
     os << std::setiosflags(std::ios::left) 
@@ -196,7 +196,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_DATA) << val
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const std::string name, const char* val) {
     os << std::setiosflags(std::ios::left) 
@@ -204,7 +204,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_DATA) << std::string(val)
       << std::endl;
     return 0;
-  };
+  }
 
 
   // Real
@@ -221,7 +221,7 @@ namespace symPACK{
       << std::resetiosflags(std::ios::showpos)
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const char* name, Real val) {
     os << std::setiosflags(std::ios::left) 
@@ -233,7 +233,7 @@ namespace symPACK{
       << std::resetiosflags(std::ios::showpos)
       << std::endl;
     return 0;
-  };
+  }
 
 
   inline Int Print(std::ostream &os, const std::string name, Real val, const std::string unit) {
@@ -247,7 +247,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << unit 
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const char *name, Real val, const char *unit) {
     os << std::setiosflags(std::ios::left) 
@@ -260,7 +260,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << std::string(unit) 
       << std::endl;
     return 0;
-  };
+  }
 
   // Two real numbers
   inline Int Print(std::ostream &os, const std::string name1, Real val1, const std::string unit1,
@@ -278,7 +278,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << unit2 
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const char *name1, Real val1, const char *unit1,
       char *name2, Real val2, char *unit2) {
@@ -295,7 +295,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << std::string(unit2) 
       << std::endl;
     return 0;
-  };
+  }
 
   // Int and Real
   inline Int Print(std::ostream &os, const std::string name1, Int val1, const std::string unit1,
@@ -313,7 +313,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << unit2 
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const char *name1, Int val1, const char *unit1,
       char *name2, Real val2, char *unit2) {
@@ -330,7 +330,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << std::string(unit2) 
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, 
       const char *name1, Int val1, 
@@ -349,7 +349,7 @@ namespace symPACK{
       << std::resetiosflags(std::ios::showpos)
       << std::endl;
     return 0;
-  };
+  }
 
 
   inline Int Print(std::ostream &os, 
@@ -372,7 +372,7 @@ namespace symPACK{
       << std::resetiosflags(std::ios::showpos)
       << std::endl;
     return 0;
-  };
+  }
 
   // Int
 
@@ -383,7 +383,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_DATA) << val
       << std::endl;
     return 0;
-  };
+  }
 
 
   inline Int Print(std::ostream &os, const char *name, Int val) {
@@ -392,7 +392,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_DATA) << val
       << std::endl;
     return 0;
-  };
+  }
 
 
   inline Int Print(std::ostream &os, const std::string name, Int val, const std::string unit) {
@@ -402,7 +402,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << unit 
       << std::endl;
     return 0;
-  };
+  }
 
 
   inline Int Print(std::ostream &os, const char* name, Int val, const std::string unit) {
@@ -412,7 +412,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << unit 
       << std::endl;
     return 0;
-  };
+  }
 
 
 
@@ -428,7 +428,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << unit2 
       << std::endl;
     return 0;
-  };
+  }
 
   inline Int Print(std::ostream &os, const char *name1, Int val1, const char *unit1,
       char *name2, Int val2, char *unit2) {
@@ -441,7 +441,7 @@ namespace symPACK{
       << std::setw(LENGTH_VAR_UNIT) << std::string(unit2) 
       << std::endl;
     return 0;
-  };
+  }
 
   // Bool
 
@@ -454,7 +454,7 @@ namespace symPACK{
     else
       os << std::setw(LENGTH_VAR_NAME) << "false" << std::endl;
     return 0;
-  };
+  }
 
 
   inline Int Print(std::ostream &os, const char* name, bool val) {
@@ -465,7 +465,7 @@ namespace symPACK{
     else
       os << std::setw(LENGTH_VAR_NAME) << "false" << std::endl;
     return 0;
-  };
+  }
 
   // *********************************************************************
   // Overload << and >> operators for basic data types


### PR DESCRIPTION
C++ function definitions should not be followed by a semicolon.

Fixes warnings from gcc-9 -pedantic