### PR TITLE
Fix syntax for -std=c++2a and -pedantic -std=c++11

### DIFF
--- a/include/sympack/IntervalTree.hpp
+++ b/include/sympack/IntervalTree.hpp
@@ -76,7 +76,7 @@ namespace symPACK{
 
       // A utility function to check if given two intervals overlap
       inline bool doOVerlap_(const Interval<F> &i1,const Interval<F> &i2);
-      inline bool doOVerlap_(const ITree::Interval<F> &i1, const Int & low, const Int & high);
+      inline bool doOVerlap_(const Interval<F> &i1, const Int & low, const Int & high);
       inline Interval<F> *intervalSearch_(ITNode<F> *root, const Int & begin, const Int & end);
       inline Interval<F> *intervalSearch_(ITNode<F> *root, const Int & begin, const Int &end, Interval<F> * & closestR, Interval<F> * & closestL);
 

--- a/include/sympack/impl/IntervalTree_impl.hpp
+++ b/include/sympack/impl/IntervalTree_impl.hpp
@@ -6,10 +6,10 @@
 
 // A utility function to create a new Interval Search Tree Node
   template<typename F>
-inline ITree<F>::ITNode<F> * ITree<F>::newNode_(ITree<F>::Interval<F> & i)
+inline typename ITree<F>::template ITNode<F> * ITree<F>::newNode_(typename ITree<F>::template Interval<F> & i)
 {
-  ITree<F>::ITNode<F> *temp = new ITree<F>::ITNode<F>;
-  temp->i = new ITree<F>::Interval<F>(i);
+  ITree<F>::ITNode<F> *temp = new typename ITree<F>::template ITNode<F>;
+  temp->i = new typename ITree<F>::template Interval<F>(i);
   temp->max = i.high;
   temp->left = temp->right = nullptr;
   temp->height = 1;
@@ -52,7 +52,7 @@ inline   Int ITree<F>::min_(ITree<F>::ITNode<F> *N)
 // This is similar to BST Insert.  Here the low value of interval
 // is used tomaintain BST property
   template<typename F>
-inline   ITree<F>::ITNode<F> * ITree<F>::insert_(ITree<F>::ITNode<F> *root, ITree<F>::Interval<F> & i)
+inline typename  ITree<F>::template ITNode<F> * ITree<F>::insert_(typename ITree<F>::template ITNode<F> *root, typename ITree<F>::template Interval<F> & i)
 {
   assert(i.low<=i.high);
 
@@ -154,7 +154,7 @@ inline   bool ITree<F>::doOVerlap_(const ITree<F>::Interval<F> &i1, const Int & 
 // The main function that searches a given interval i in a given
 // Interval Tree.
   template<typename F>
-inline   ITree<F>::Interval<F> * ITree<F>::intervalSearch_(ITree<F>::ITNode<F> *root,const Int & begin,const Int &end)
+inline typename ITree<F>::template Interval<F> * ITree<F>::intervalSearch_(typename ITree<F>::template ITNode<F> *root,const Int & begin,const Int &end)
 {
   // Base Case, tree is empty
   if (root == nullptr){
@@ -179,7 +179,7 @@ inline   ITree<F>::Interval<F> * ITree<F>::intervalSearch_(ITree<F>::ITNode<F> *
 
 
   template<typename F>
-inline   ITree<F>::Interval<F> * ITree<F>::intervalSearch_(ITree<F>::ITNode<F> *root,const Int & begin,const Int &end, Interval<F> * & closestR, Interval<F> * & closestL)
+inline typename ITree<F>::template Interval<F> * ITree<F>::intervalSearch_(typename ITree<F>::template ITNode<F> *root,const Int & begin,const Int &end, Interval<F> * & closestR, Interval<F> * & closestL)
 {
   // Base Case, tree is empty
   if (root == nullptr){

--- a/include/sympack/impl/symPACKMatrix_impl.hpp
+++ b/include/sympack/impl/symPACKMatrix_impl.hpp
@@ -198,7 +198,7 @@ namespace symPACK{
 
 
 
-        Task.getHash = [&](char * ameta=nullptr)->GenericTask::id_type{
+        Task.getHash = [&](char * ameta)->GenericTask::id_type{
           char * pmeta = ameta;
           std::stringstream sstr;
           sstr<<meta[0]<<"_"<<meta[1]<<"_"<<0<<"_"<<(Int)(*reinterpret_cast<Factorization::op_type*>(&meta[3]));


### PR DESCRIPTION
    Fix syntax for nested templates that breaks w/ -std=c++2a
    
    This was causing errors on g++ 9.2.0 w/ -std=c++2a
    
    Also validated using all of: c++11, c++14 and c++17 w/ -pedantic


    Remove an (unused) argument default to a lambda
    
    C++11 prohibits default arguments to lambdas
    
    https://stackoverflow.com/questions/14189585
