### PR TITLE
conditionally change future::ready() to future::is_ready()

### DIFF
--- a/src/CommPull.cpp
+++ b/src/CommPull.cpp
@@ -187,10 +187,18 @@ namespace symPACK{
     scope_timer(a,IN_MSG_ISDONE);
     if(async_get){
       {
+#if UPCXX_VERSION >= 20230305
+	isDone = f_get.is_ready();
+#else
         isDone = f_get.ready();
+#endif
         if(!isDone){
           upcxx::progress();
+#if UPCXX_VERSION >= 20230305
+          isDone = f_get.is_ready();
+#else
           isDone = f_get.ready();
+#endif
         }
         return isDone; 
       }


### PR DESCRIPTION
Changes calls from upcxx::future::ready() to upcxx::future::is_ready(), conditional upon a proper version of UPC++