### PR TITLE
fix FindSCOTCH module

### DIFF
--- a/cmake/Modules/FindSCOTCH.cmake
+++ b/cmake/Modules/FindSCOTCH.cmake
@@ -91,6 +91,8 @@
 cmake_minimum_required( VERSION 3.11 ) # Require CMake 3.11+
 # Set up some auxillary vars if hints have been set
 
+set (scotch_PREFIX $ENV{scotch_PREFIX})
+
 if( scotch_PREFIX AND NOT scotch_INCLUDE_DIR )
   set( scotch_INCLUDE_DIR ${scotch_PREFIX}/include )
 endif()
@@ -207,10 +209,11 @@ if( EXISTS ${SCOTCH_INCLUDE_DIR}/scotch.h )
   )
   file( STRINGS ${SCOTCH_INCLUDE_DIR}/scotch.h scotch_idxwidth
         REGEX ${idxwidth_pattern} )
-
-  string( REGEX REPLACE ${idxwidth_pattern} 
+  if (DEFINED SCOTCH_IDXWIDTH_STRING)
+    string( REGEX REPLACE ${idxwidth_pattern} 
           "${SCOTCH_IDXWIDTH_STRING}\\1"
           SCOTCH_IDXWIDTH_STRING ${scotch_idxwidth} )
+  endif()
 
   if( ${SCOTCH_IDXWIDTH_STRING} MATCHES "int64_t" )
     set( SCOTCH_USES_ILP64 TRUE )


### PR DESCRIPTION
The `FindSCOTCH.cmake` module that is used when `-DENABLE_SCOTCH=ON` is used during build configuration did not work properly. Two errors were happening.

1. The `scotch_PREFIX` variable in `FindSCOTCH.cmake` is supposed to be set to the `scotch_PREFIX` environment variable that the documentation instructs the user to set prior to attempting to build symPACK with SCOTCH. This was not happening in the original version of the module, which led to certain variables later in the file being undefined when they should not have been. This caused a cmake error thanks to the `SCOTCH_LIBRARY_DIR` variable being improperly undefined. Line 94 in the PR fixes this.
2. The `SCOTCH_IDXWIDTH_STRING` variable is undefined by default, and if it is undefined, the call to `string(REGEX REPLACE ...)` causes an error. I've added a conditional that checks to see if `SCOTCH_IDXWIDTH_STRING` is defined before issuing the call to `string(REGEX REPLACE ...)`.

These changes make it possible to build symPACK using SCOTCH without error by simply following the instructions in the README. 